### PR TITLE
Further WIP: DNS discovery client implementation

### DIFF
--- a/discovery/dnsdisc/client.nim
+++ b/discovery/dnsdisc/client.nim
@@ -1,7 +1,7 @@
 {.push raises: [Defect]}
 
 import
-  std/strformat,
+  std/[sets, strformat],
   chronicles,
   chronos,
   eth/keys,
@@ -12,11 +12,20 @@ import
 export
   tree
 
+## Implementation of DNS-based discovery client protocol, as specified
+## in https://eips.ethereum.org/EIPS/eip-1459
+## 
+## This implementation is loosely based on the Go implementation of EIP-1459
+## at https://github.com/ethereum/go-ethereum/blob/master/p2p/dnsdisc
+
+logScope:
+  topics = "dnsdisc.client"
+
 type
   Client* = object
     ## For now a client contains only a single tree in a single location
     loc*: LinkEntry
-    tree*: var Tree
+    tree*: Tree
   
   ## A Resolver proc takes a DNS domain as argument and
   ## returns the TXT record at that domain
@@ -77,13 +86,41 @@ proc resolveSubtreeEntry*(resolver: Resolver, loc: LinkEntry, subdomain: string)
     
   return ok(res[])
 
-proc resolveAllEntries(rootEntry: RootEntry): ResolveResult[seq[SubtreeEntry]] =
+proc resolveAllEntries*(resolver: Resolver, loc: LinkEntry, rootEntry: RootEntry): Future[seq[SubtreeEntry]] {.async.} =
   ## Resolves all subtree entries at given root
   ## Follows EIP-1459 client protocol
-  ## 
-  ## @TODO implement
   
-  ok(newSeq[SubtreeEntry]())
+  var subtreeEntries: seq[SubtreeEntry]
+  
+  # Initialise a hash set with the root hashes of ENR and link subtrees
+  var hashes = toHashSet([rootEntry.eroot, rootEntry.lroot])
+
+  while hashes.len > 0:
+    # Recursively resolve leaf entries and add to return list.
+    # @TODO: Should we add a depth limit here?
+
+    let
+      # Resolve and remove random entry from subdomain hashes
+      nextHash = hashes.pop()
+      nextEntry = await resolveSubtreeEntry(resolver, loc, nextHash)
+    
+    if nextEntry.isErr():
+      # @TODO metrics to track missing/failed entries
+      trace "Could not resolve next entry. Continuing.", subdomain=nextHash
+      continue
+    
+    case nextEntry[].kind:
+      of Enr:
+        # Add to return list
+        subtreeEntries.add(nextEntry[])
+      of Link:
+        # Add to return list
+        subtreeEntries.add(nextEntry[])
+      of Branch:
+        # Add branch children to hashes, and continue resolving
+        hashes.incl(nextEntry[].branchEntry.children.toHashSet())
+  
+  return subtreeEntries
 
 proc verifySignature(rootEntry: RootEntry, pubKey: PublicKey): bool {.raises: [Defect, ValueError].} =
   ## Verifies the signature on the root against the public key
@@ -141,13 +178,15 @@ proc resolveRoot*(resolver: Resolver, loc: LinkEntry): Future[ResolveResult[Root
     
   return ok(res[])
 
-proc syncTree*(c: Client, resolver: Resolver): Tree {.raises: [Defect, CatchableError].} =
+proc syncTree*(c: var Client, resolver: Resolver): Tree {.raises: [Defect, CatchableError].} =
   ## Synchronises the client tree according to EIP-1459
-  ## 
-  ## @TODO implement - this is a stub
-
-  c.tree = Tree(rootEntry: (waitFor resolveRoot(resolver, c.loc)).tryGet(),
-                entries: resolveAllEntries(c.tree.rootEntry).tryGet())
+  
+  let
+    rootEntry = (waitFor resolveRoot(resolver, c.loc)).tryGet()
+    subtreeEntries = waitFor resolveAllEntries(resolver, c.loc, rootEntry)
+ 
+  c.tree = Tree(rootEntry: rootEntry,
+                entries: subtreeEntries)
 
   return c.tree
 
@@ -155,7 +194,7 @@ proc syncTree*(c: Client, resolver: Resolver): Tree {.raises: [Defect, Catchable
 # Client API #
 ##############
 
-proc getTree*(c: Client, resolver: Resolver): Tree {.raises: [Defect, CatchableError].} =
+proc getTree*(c: var Client, resolver: Resolver): Tree {.raises: [Defect, CatchableError].} =
   ## Main entry point into the client
   ## Returns a synchronised copy of the tree
   ## at the configured client domain

--- a/discovery/dnsdisc/client.nim
+++ b/discovery/dnsdisc/client.nim
@@ -92,12 +92,15 @@ proc resolveAllEntries*(resolver: Resolver, loc: LinkEntry, rootEntry: RootEntry
   
   var subtreeEntries: seq[SubtreeEntry]
   
-  # Initialise a hash set with the root hashes of ENR and link subtrees
-  var hashes = toHashSet([rootEntry.eroot, rootEntry.lroot])
+  var
+    # Initialise a hash set with the root hashes of ENR and link subtrees
+    hashes = toHashSet([rootEntry.eroot, rootEntry.lroot])
+    i = 1
 
-  while hashes.len > 0:
+  while hashes.len > 0 and i <= 100:
     # Recursively resolve leaf entries and add to return list.
-    # @TODO: Should we add a depth limit here?
+    # @TODO: Define a better depth limit. 100 was chosen arbitrarily.
+    inc(i)
 
     let
       # Resolve and remove random entry from subdomain hashes

--- a/tests/test_client.nim
+++ b/tests/test_client.nim
@@ -1,21 +1,32 @@
 {.used.}
 
 import
-  std/strutils,
+  std/[sequtils, strutils, tables],
   chronos,
   stew/base64,
   testutils/unittests,
   ../discovery/dnsdisc/[tree, client]
 
 procSuite "Test DNS Discovery: Client":
+
+  # Suite setup
+  # Create sample tree from EIP-1459
+  var treeRecords = initTable[string, string]()
+  treeRecords["nodes.example.org"] = "enrtree-root:v1 e=JWXYDBPXYWG6FX3GMDIBFA6CJ4 l=C7HRFPF3BLGF3YR4DY5KX3SMBE seq=1 sig=o908WmNp7LibOfPsr4btQwatZJ5URBr2ZAuxvK4UWHlsB9sUOTJQaGAlLPVAhM__XJesCHxLISo94z5Z2a463gA"
+  treeRecords["C7HRFPF3BLGF3YR4DY5KX3SMBE.nodes.example.org"] = "enrtree://AM5FCQLWIZX2QFPNJAP7VUERCCRNGRHWZG3YYHIUV7BVDQ5FDPRT2@morenodes.example.org"
+  treeRecords["JWXYDBPXYWG6FX3GMDIBFA6CJ4.nodes.example.org"] = "enrtree-branch:2XS2367YHAXJFGLZHVAWLQD4ZY,H4FHT4B454P6UXFD7JCYQ5PWDY,MHTDO6TMUBRIA2XWG5LUDACK24"
+  treeRecords["2XS2367YHAXJFGLZHVAWLQD4ZY.nodes.example.org"] = "enr:-HW4QOFzoVLaFJnNhbgMoDXPnOvcdVuj7pDpqRvh6BRDO68aVi5ZcjB3vzQRZH2IcLBGHzo8uUN3snqmgTiE56CH3AMBgmlkgnY0iXNlY3AyNTZrMaECC2_24YYkYHEgdzxlSNKQEnHhuNAbNlMlWJxrJxbAFvA"
+  treeRecords["H4FHT4B454P6UXFD7JCYQ5PWDY.nodes.example.org"] = "enr:-HW4QAggRauloj2SDLtIHN1XBkvhFZ1vtf1raYQp9TBW2RD5EEawDzbtSmlXUfnaHcvwOizhVYLtr7e6vw7NAf6mTuoCgmlkgnY0iXNlY3AyNTZrMaECjrXI8TLNXU0f8cthpAMxEshUyQlK-AM0PW2wfrnacNI"
+  treeRecords["MHTDO6TMUBRIA2XWG5LUDACK24.nodes.example.org"] = "enr:-HW4QLAYqmrwllBEnzWWs7I5Ev2IAs7x_dZlbYdRdMUx5EyKHDXp7AV5CkuPGUPdvbv1_Ms1CPfhcGCvSElSosZmyoqAgmlkgnY0iXNlY3AyNTZrMaECriawHKWdDRk2xeZkrOXBQ0dfMFLHY4eENZwdufn1S1o"
+
+  proc resolver(domain: string): Future[string] {.async.} =
+    return treeRecords[domain]
+
   asyncTest "Resolve root":
     ## This tests resolving a root TXT entry at a given domain location,
     ## parsing the entry and verifying the signature.
     
     # Expected case
-
-    proc resolver(domain: string): Future[string] {.async.} =
-      return "enrtree-root:v1 e=JWXYDBPXYWG6FX3GMDIBFA6CJ4 l=C7HRFPF3BLGF3YR4DY5KX3SMBE seq=1 sig=o908WmNp7LibOfPsr4btQwatZJ5URBr2ZAuxvK4UWHlsB9sUOTJQaGAlLPVAhM__XJesCHxLISo94z5Z2a463gA"
 
     let
       loc = parseLinkEntry("enrtree://AKPYQIUQIL7PSIACI32J7FGZW56E5FKHEFCCOFHILBIMW3M6LWXS2@nodes.example.org").tryGet()
@@ -41,10 +52,7 @@ procSuite "Test DNS Discovery: Client":
     ## parsing the entry and verifying the subdomain hash.
     
     # Expected case
-    
-    proc resolver(domain: string): Future[string] {.async.} =
-      return "enr:-HW4QOFzoVLaFJnNhbgMoDXPnOvcdVuj7pDpqRvh6BRDO68aVi5ZcjB3vzQRZH2IcLBGHzo8uUN3snqmgTiE56CH3AMBgmlkgnY0iXNlY3AyNTZrMaECC2_24YYkYHEgdzxlSNKQEnHhuNAbNlMlWJxrJxbAFvA"
-    
+
     let
       loc = parseLinkEntry("enrtree://AKPYQIUQIL7PSIACI32J7FGZW56E5FKHEFCCOFHILBIMW3M6LWXS2@nodes.example.org").tryGet()
       entry = waitFor resolveSubtreeEntry(resolver, loc, "2XS2367YHAXJFGLZHVAWLQD4ZY")
@@ -55,9 +63,100 @@ procSuite "Test DNS Discovery: Client":
       entry[].enrEntry == parseEnrEntry("enr:-HW4QOFzoVLaFJnNhbgMoDXPnOvcdVuj7pDpqRvh6BRDO68aVi5ZcjB3vzQRZH2IcLBGHzo8uUN3snqmgTiE56CH3AMBgmlkgnY0iXNlY3AyNTZrMaECC2_24YYkYHEgdzxlSNKQEnHhuNAbNlMlWJxrJxbAFvA").tryGet()
 
     # Invalid cases
+    # Add invalid entry to example tree
+    treeRecords["2XS2367YHAXJFGLZHVAWLQE4ZY.nodes.example.org"] = "enr:-HW4QOFzoVLaFJnNhbgMoDXPnOvcdVuj7pDpqRvh6BRDO68aVi5ZcjB3vzQRZH2IcLBGHzo8uUN3snqmgTiE56CH3AMBgmlkgnY0iXNlY3AyNTZrMaECC2_24YYkYHEgdzxlSNKQEnHhuNAbNlMlWJxrJxbAFvA"
 
     check:
       # Invalid hash
       (waitFor resolveSubtreeEntry(resolver, loc, "2XS2367YHAXJFGLZHVAWLQE4ZY"))
       .error()
       .contains("Could not verify subdomain hash")
+    
+    # Remove invalid entry for future tests
+    treeRecords.del("2XS2367YHAXJFGLZHVAWLQE4ZY.nodes.example.org")
+
+  asyncTest "Resolve all subtree entries":
+    ## This tests resolving all subtree entries at a given root,
+    ## parsing and verifying the entries
+    
+    # Expected case
+
+    let
+      loc = parseLinkEntry("enrtree://AKPYQIUQIL7PSIACI32J7FGZW56E5FKHEFCCOFHILBIMW3M6LWXS2@nodes.example.org").tryGet()
+      rootEntry = (waitFor resolveRoot(resolver, loc)).tryGet()
+      entries = waitFor resolveAllEntries(resolver, loc, rootEntry)
+    
+    # We expect 3 ENR entries and one link entry
+    let
+      enrs = entries.filterIt(it.kind == Enr).mapIt(it.enrEntry)
+      links = entries.filterIt(it.kind == Link).mapIt(it.linkEntry)
+    
+    check:
+      entries.len == 4
+      enrs.len == 3
+      enrs.contains(parseEnrEntry("enr:-HW4QOFzoVLaFJnNhbgMoDXPnOvcdVuj7pDpqRvh6BRDO68aVi5ZcjB3vzQRZH2IcLBGHzo8uUN3snqmgTiE56CH3AMBgmlkgnY0iXNlY3AyNTZrMaECC2_24YYkYHEgdzxlSNKQEnHhuNAbNlMlWJxrJxbAFvA").tryGet())
+      enrs.contains(parseEnrEntry("enr:-HW4QAggRauloj2SDLtIHN1XBkvhFZ1vtf1raYQp9TBW2RD5EEawDzbtSmlXUfnaHcvwOizhVYLtr7e6vw7NAf6mTuoCgmlkgnY0iXNlY3AyNTZrMaECjrXI8TLNXU0f8cthpAMxEshUyQlK-AM0PW2wfrnacNI").tryGet())
+      enrs.contains(parseEnrEntry("enr:-HW4QLAYqmrwllBEnzWWs7I5Ev2IAs7x_dZlbYdRdMUx5EyKHDXp7AV5CkuPGUPdvbv1_Ms1CPfhcGCvSElSosZmyoqAgmlkgnY0iXNlY3AyNTZrMaECriawHKWdDRk2xeZkrOXBQ0dfMFLHY4eENZwdufn1S1o").tryGet())
+      links.len == 1
+      links.contains(parseLinkEntry("enrtree://AM5FCQLWIZX2QFPNJAP7VUERCCRNGRHWZG3YYHIUV7BVDQ5FDPRT2@morenodes.example.org").tryGet())
+    
+    # Invalid case
+    proc invalidResolver(domain: string): Future[string] {.async.} =
+      return ""
+
+    check:
+      # If no entries can be resolved without error, empty set will be returned
+      (waitFor resolveAllEntries(invalidResolver, loc, rootEntry)).len == 0
+
+  asyncTest "Sync tree":
+    ## This tests creating a client at a specific domain location
+    ## and syncing the entire tree at that location
+    
+    # Expected case
+    
+    let loc = parseLinkEntry("enrtree://AKPYQIUQIL7PSIACI32J7FGZW56E5FKHEFCCOFHILBIMW3M6LWXS2@nodes.example.org").tryGet()
+    
+    var
+      client = Client(loc: loc, tree: Tree())
+      tree = client.getTree(resolver)
+    
+    # Verify root
+    check:
+      tree.rootEntry.eroot == "JWXYDBPXYWG6FX3GMDIBFA6CJ4"
+      tree.rootEntry.lroot == "C7HRFPF3BLGF3YR4DY5KX3SMBE"
+      tree.rootEntry.seqNo == 1
+      tree.rootEntry.signature == Base64Url.decode("o908WmNp7LibOfPsr4btQwatZJ5URBr2ZAuxvK4UWHlsB9sUOTJQaGAlLPVAhM__XJesCHxLISo94z5Z2a463gA")
+
+    # Verify subtree entries
+    let
+      enrs = tree.getNodes()
+      links = tree.getLinks()
+    
+    check:
+      tree.entries.len == 4
+      enrs.len == 3
+      enrs.contains(parseEnrEntry("enr:-HW4QOFzoVLaFJnNhbgMoDXPnOvcdVuj7pDpqRvh6BRDO68aVi5ZcjB3vzQRZH2IcLBGHzo8uUN3snqmgTiE56CH3AMBgmlkgnY0iXNlY3AyNTZrMaECC2_24YYkYHEgdzxlSNKQEnHhuNAbNlMlWJxrJxbAFvA").tryGet())
+      enrs.contains(parseEnrEntry("enr:-HW4QAggRauloj2SDLtIHN1XBkvhFZ1vtf1raYQp9TBW2RD5EEawDzbtSmlXUfnaHcvwOizhVYLtr7e6vw7NAf6mTuoCgmlkgnY0iXNlY3AyNTZrMaECjrXI8TLNXU0f8cthpAMxEshUyQlK-AM0PW2wfrnacNI").tryGet())
+      enrs.contains(parseEnrEntry("enr:-HW4QLAYqmrwllBEnzWWs7I5Ev2IAs7x_dZlbYdRdMUx5EyKHDXp7AV5CkuPGUPdvbv1_Ms1CPfhcGCvSElSosZmyoqAgmlkgnY0iXNlY3AyNTZrMaECriawHKWdDRk2xeZkrOXBQ0dfMFLHY4eENZwdufn1S1o").tryGet())
+      links.len == 1
+      links.contains(parseLinkEntry("enrtree://AM5FCQLWIZX2QFPNJAP7VUERCCRNGRHWZG3YYHIUV7BVDQ5FDPRT2@morenodes.example.org").tryGet())
+    
+    # Invalid cases
+    proc invalidResolver(domain: string): Future[string] {.async.} =
+      return ""
+
+    proc validRootResolver(domain: string): Future[string] {.async.} =
+      return "enrtree-root:v1 e=JWXYDBPXYWG6FX3GMDIBFA6CJ4 l=C7HRFPF3BLGF3YR4DY5KX3SMBE seq=1 sig=o908WmNp7LibOfPsr4btQwatZJ5URBr2ZAuxvK4UWHlsB9sUOTJQaGAlLPVAhM__XJesCHxLISo94z5Z2a463gA"
+    
+    # Invalid case 1: Root entry fails to parse
+    expect CatchableError:
+      # Expect ResultError if not even root entry can be resolved
+      discard client.getTree(invalidResolver)
+    
+    # Invalid case 2: Root parses, but no subtree entries
+    let errTree = client.getTree(validRootResolver)
+
+    check:
+      # Root parses as expected, but no entries resolved
+      errTree.rootEntry == parseRootEntry("enrtree-root:v1 e=JWXYDBPXYWG6FX3GMDIBFA6CJ4 l=C7HRFPF3BLGF3YR4DY5KX3SMBE seq=1 sig=o908WmNp7LibOfPsr4btQwatZJ5URBr2ZAuxvK4UWHlsB9sUOTJQaGAlLPVAhM__XJesCHxLISo94z5Z2a463gA").tryGet()
+      errTree.entries.len == 0


### PR DESCRIPTION
## Background

This PR completes the basic implementation of the DNS discovery client as set out in https://github.com/status-im/nim-waku/issues/617

It adds and tests the following functionality to the client, following the client protocol in EIP-1459
- recursively resolve, parse and verify _all_ ENR and link entries for the subtrees defined by a given root entry
- sync the complete tree with all subtree entries at a given domain

## Next steps

* Add DNS TXT resolver (https://github.com/status-im/nim-waku/issues/615)
* Repo management: improve CI, README and add manual
* Integrate with `nim-waku`, mapping ENR to `libp2p` `multiaddrs`
* Allow clients to create, modify and publish their own trees
* More sophisticated syncing, e.g. automatic periodic syncing, following link entries, etc.