### PR TITLE
test refc in Nim 2.0 and newer in addition to ORC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     
     steps:
       - name: Checkout nim-dnsdisc
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # We need to do this because of how github cache works
       # I am not sure we can move the cache file, so if we do not do this

--- a/dnsdisc.nimble
+++ b/dnsdisc.nimble
@@ -8,7 +8,7 @@ license       = "MIT or Apache License 2.0"
 
 # Dependencies
 
-requires "nim >= 1.2.0",
+requires "nim >= 1.6.0",
   "bearssl",
   "chronicles",
   "chronos",
@@ -28,13 +28,17 @@ proc buildBinary(name: string, srcDir = "./", params = "", lang = "c") =
   var extra_params = params
   for i in 2..<paramCount():
     extra_params &= " " & paramStr(i)
-  exec "nim " & lang & " --out:build/" & name & " " & extra_params & " " & srcDir & name & ".nim"
+  exec "nim " & lang & " --mm:refc --out:build/" & name & " " & extra_params & " " & srcDir & name & ".nim"
+  if NimMajor >= 2:
+    exec "nim " & lang & " --mm:orc --out:build/" & name & " " & extra_params & " " & srcDir & name & ".nim"
 
 proc test(name: string, params = "-d:chronicles_log_level=DEBUG", lang = "c") =
   # XXX: When running `> NIM_PARAMS="-d:chronicles_log_level=INFO" make test2`
   # I expect compiler flag to be overridden, however it stays with whatever is
   # specified here.
-  exec "nim " & lang & " -r " & params & " tests/" & name & ".nim"
+  exec "nim " & lang & " --mm:refc -r " & params & " tests/" & name & ".nim"
+  if NimMajor >= 2:
+    exec "nim " & lang & " --mm:orc -r " & params & " tests/" & name & ".nim"
 
 task creator, "Build DNS discovery tree creator":
   buildBinary "tree_creator", "dnsdisc/creator/", "-d:chronicles_log_level=DEBUG -d:chronosStrictException"

--- a/dnsdisc/builder.nim
+++ b/dnsdisc/builder.nim
@@ -1,4 +1,4 @@
-{.push raises: [Defect]}
+{.push raises: []}
 
 import
   std/[sequtils, strformat, strutils, tables],

--- a/dnsdisc/client.nim
+++ b/dnsdisc/client.nim
@@ -1,4 +1,4 @@
-{.push raises: [Defect]}
+{.push raises: []}
 
 import
   std/[sequtils, sets, strformat],
@@ -40,7 +40,7 @@ const
 # Tree sync functions #
 #######################
 
-proc parseAndVerifySubtreeEntry(txtRecord: string, hashStr: string): EntryParseResult[SubtreeEntry] {.raises: [Defect, ValueError, Base32Error].} =
+proc parseAndVerifySubtreeEntry(txtRecord: string, hashStr: string): EntryParseResult[SubtreeEntry] {.raises: [ValueError, Base32Error].} =
   ## Parses subtree TXT entry and verifies that it matches the hash
 
   let res = parseSubtreeEntry(txtRecord)
@@ -64,7 +64,7 @@ proc parseAndVerifySubtreeEntry(txtRecord: string, hashStr: string): EntryParseR
 
   ok(subtreeEntry)
 
-proc resolveSubtreeEntry*(resolver: Resolver, loc: LinkEntry, subdomain: string): Future[ResolveResult[SubtreeEntry]] {.async, gcsafe, raises: [Defect, ValueError, Base32Error].} =
+proc resolveSubtreeEntry*(resolver: Resolver, loc: LinkEntry, subdomain: string): Future[ResolveResult[SubtreeEntry]] {.async, gcsafe, raises: [ValueError, Base32Error].} =
   ## Resolves subtree entry at given subdomain
   ## Follows EIP-1459 client protocol
 
@@ -223,7 +223,7 @@ proc getNodeRecords*(c: Client): seq[Record] =
   except ValueError:
     return @[]
 
-proc getTree*(c: var Client, resolver: Resolver): Tree {.raises: [Defect, CatchableError].} =
+proc getTree*(c: var Client, resolver: Resolver): Tree {.raises: [CatchableError].} =
   ## Main entry point into the client
   ## Returns a synchronised copy of the tree
   ## at the configured client domain

--- a/dnsdisc/creator/tree_creator.nim
+++ b/dnsdisc/creator/tree_creator.nim
@@ -1,4 +1,4 @@
-{.push raises: [Defect]}
+{.push raises: []}
 
 ## A utility module to create a Merkle tree encoding
 ## a list of ENR and link entries. This is a standalone
@@ -10,7 +10,7 @@ import
   chronos,
   chronicles,
   stew/base32,
-  stew/results,
+  results,
   ../builder
 
 logScope:

--- a/dnsdisc/creator/tree_creator_conf.nim
+++ b/dnsdisc/creator/tree_creator_conf.nim
@@ -2,7 +2,7 @@ import
   confutils, confutils/defs, confutils/std/net,
   eth/p2p/discoveryv5/enr,
   eth/keys,
-  stew/results,
+  results,
   ../tree
 
 type

--- a/dnsdisc/creator/tree_creator_rpc.nim
+++ b/dnsdisc/creator/tree_creator_rpc.nim
@@ -1,11 +1,11 @@
-{.push raises: [Defect].}
+{.push raises: [].}
 
 import
   std/tables,
   chronicles,
   json_rpc/rpcserver,
   stew/shims/net,
-  stew/results,
+  results,
   ./tree_creator,
   json_serialization/std/[options, tables]
 
@@ -48,7 +48,7 @@ proc installRpcApiHandlers(initTc: TreeCreator, rpcsrv: RpcServer)
     return url
 
 proc startRpc*(tc: var TreeCreator, rpcIp: ValidIpAddress, rpcPort: Port)
-  {.raises: [Defect, RpcBindError, CatchableError].} =
+  {.raises: [RpcBindError, CatchableError].} =
   info "Starting RPC server"
   let
     ta = initTAddress(rpcIp, rpcPort)

--- a/dnsdisc/tree.nim
+++ b/dnsdisc/tree.nim
@@ -1,4 +1,4 @@
-{.push raises: [Defect]}
+{.push raises: []}
 
 import
   std/[strformat, strscans, strutils, sequtils],
@@ -85,7 +85,7 @@ proc isValidHash(hashStr: string): bool =
 
   return true
 
-proc hashableContent*(rootEntry: RootEntry): seq[byte] {.raises: [Defect, ValueError].} =
+proc hashableContent*(rootEntry: RootEntry): seq[byte] {.raises: [ValueError].} =
   # Returns the hashable content of a root entry, used to compute the `sig=` portion
   return fmt"{RootPrefix} e={rootEntry.eroot} l={rootEntry.lroot} seq={rootEntry.seqNo}".toBytes()
 
@@ -216,13 +216,13 @@ proc parseSubtreeEntry*(entry: string): EntryParseResult[SubtreeEntry] =
 # Tree accessors #
 ##################
 
-proc getNodes*(tree: Tree): seq[EnrEntry] {.raises: [Defect, ValueError]} =
+proc getNodes*(tree: Tree): seq[EnrEntry] {.raises: [ValueError]} =
   ## Returns a list of node entries in the tree
 
   return tree.entries.filterIt(it.kind == Enr)
                      .mapIt(it.enrEntry)
 
-proc getLinks*(tree: Tree): seq[LinkEntry] {.raises: [Defect, ValueError]} =
+proc getLinks*(tree: Tree): seq[LinkEntry] {.raises: [ValueError]} =
   ## Returns a list of link entries in the tree
 
   return tree.entries.filterIt(it.kind == Link)


### PR DESCRIPTION
It now depends on several 1.6-only modules, so it's most useful to simply mark this as requiring 1.6 also.

The `Defect`s were for Nim 1.2 compatibility, but with 1.6, they're unnecessary and create additional compile-time hints and warnings.

`stew/results` is deprecated.