### PR TITLE
test with Nim 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,10 @@ jobs:
           - NPROC: 2
             MAKEFLAGS: "-j${NPROC}"
             NIMFLAGS: "--parallelBuild:${NPROC}"
+        branch: [version-1-6, version-2-0]
         os: [ubuntu-latest, macos-latest]
     
-    name: '${{ matrix.os }}'
+    name: '${{ matrix.os }} (Nim ${{ matrix.branch }})'
     runs-on: ${{ matrix.os }}
     
     steps:
@@ -36,5 +37,13 @@ jobs:
           path: vendor/nimbus-build-system/vendor/Nim/bin
           key: ${{ runner.os }}-${{ matrix.env.NPROC }}-nim-${{ hashFiles('.gitmodules') }}
 
+      - name: Build the Nim compiler
+        run: |
+          curl -O -L -s -S https://raw.githubusercontent.com/status-im/nimbus-build-system/master/scripts/build_nim.sh
+          env MAKE="make -j${NPROC}" CC=gcc NIM_COMMIT=${{ matrix.branch }} bash build_nim.sh nim csources dist/nimble NimBinaries
+          echo '${{ github.workspace }}/nim/bin' >> $GITHUB_PATH
+
       - name: Run tests
-        run: make test
+        run: |
+          nim --version
+          make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           - NPROC: 2
             MAKEFLAGS: "-j${NPROC}"
             NIMFLAGS: "--parallelBuild:${NPROC}"
-        branch: [version-1-6, version-2-0]
+        branch: [upstream/version-1-6, upstream/version-2-0]
         os: [ubuntu-latest, macos-latest]
     
     name: '${{ matrix.os }} (Nim ${{ matrix.branch }})'
@@ -40,5 +40,4 @@ jobs:
       - name: Run tests
         run: |
           nim --version
-          make NIMFLAGS="--mm:refc" test
-          make NIMFLAGS="--mm:orc" test
+          make NIM_COMMIT="${{ matrix.branch }}" -j"${NPROC}" test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,10 @@ jobs:
         run: git submodule update --init --recursive
 
       - name: Cache nim
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: vendor/nimbus-build-system/vendor/Nim/bin
-          key: ${{ runner.os }}-${{ matrix.env.NPROC }}-nim-${{ hashFiles('.gitmodules') }}
+          key: ${{ runner.os }}-${{ matrix.env.NPROC }}-${{ matrix.branch }}-nim-${{ hashFiles('.gitmodules') }}
 
       - name: Build the Nim compiler
         run: |
@@ -46,4 +46,5 @@ jobs:
       - name: Run tests
         run: |
           nim --version
-          make test
+          make NIM_FLAGS="--mm:refc" test
+          make NIM_FLAGS="--mm:orc" test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,6 @@ jobs:
       - name: Submodules
         run: git submodule update --init --recursive
 
-      - name: Cache nim
-        uses: actions/cache@v2
-        with:
-          path: vendor/nimbus-build-system/vendor/Nim/bin
-          key: ${{ runner.os }}-${{ matrix.env.NPROC }}-${{ matrix.branch }}-nim-${{ hashFiles('.gitmodules') }}
-
       - name: Build the Nim compiler
         run: |
           curl -O -L -s -S https://raw.githubusercontent.com/status-im/nimbus-build-system/master/scripts/build_nim.sh
@@ -46,5 +40,5 @@ jobs:
       - name: Run tests
         run: |
           nim --version
-          make NIM_FLAGS="--mm:refc" test
-          make NIM_FLAGS="--mm:orc" test
+          make NIMFLAGS="--mm:refc" test
+          make NIMFLAGS="--mm:orc" test

--- a/dnsdisc/client.nim
+++ b/dnsdisc/client.nim
@@ -1,7 +1,7 @@
-{.push raises: []}
+{.push raises: [].}
 
 import
-  std/[sequtils, sets, strformat],
+  std/[sequtils, sets],
   chronicles,
   chronos,
   eth/keys,
@@ -40,7 +40,7 @@ const
 # Tree sync functions #
 #######################
 
-proc parseAndVerifySubtreeEntry(txtRecord: string, hashStr: string): EntryParseResult[SubtreeEntry] {.raises: [ValueError, Base32Error].} =
+func parseAndVerifySubtreeEntry(txtRecord: string, hashStr: string): EntryParseResult[SubtreeEntry] {.raises: [ValueError, Base32Error].} =
   ## Parses subtree TXT entry and verifies that it matches the hash
 
   let res = parseSubtreeEntry(txtRecord)
@@ -125,7 +125,7 @@ proc resolveAllEntries*(resolver: Resolver, loc: LinkEntry, rootEntry: RootEntry
 
   return subtreeEntries
 
-proc verifySignature(rootEntry: RootEntry, pubKey: PublicKey): bool =
+func verifySignature(rootEntry: RootEntry, pubKey: PublicKey): bool =
   ## Verifies the signature on the root against the public key
   let sig = SignatureNR.fromRaw(rootEntry.signature)
 
@@ -141,7 +141,7 @@ proc verifySignature(rootEntry: RootEntry, pubKey: PublicKey): bool =
                   msg = sigHash,
                   key = pubKey)
 
-proc parseAndVerifyRoot(txtRecord: string, loc: LinkEntry): EntryParseResult[RootEntry] =
+func parseAndVerifyRoot(txtRecord: string, loc: LinkEntry): EntryParseResult[RootEntry] =
   ## Parses root TXT record and verifies signature
 
   let res = parseRootEntry(txtRecord)
@@ -203,7 +203,7 @@ proc syncTree(resolver: Resolver, rootLocation: LinkEntry): Future[Result[Tree, 
 # Client API #
 ##############
 
-proc init*(T: type Client,
+func init*(T: type Client,
            locationUrl: string): Result[T, cstring] =
   ## Initialise client from a DNS node list URL
   ## with format 'enrtree://<key>@<fqdn>'
@@ -215,7 +215,7 @@ proc init*(T: type Client,
 
   return ok(Client(loc: locLink.get()))
 
-proc getNodeRecords*(c: Client): seq[Record] =
+func getNodeRecords*(c: Client): seq[Record] =
   ## Returns a list of node records in the client tree
 
   try:

--- a/dnsdisc/tree.nim
+++ b/dnsdisc/tree.nim
@@ -1,11 +1,10 @@
-{.push raises: []}
+{.push raises: [].}
 
 import
   std/[strformat, strscans, strutils, sequtils],
   stew/[base32, base64, byteutils, results],
   eth/keys,
-  eth/p2p/discoveryv5/enr,
-  nimcrypto/[hash, keccak]
+  eth/p2p/discoveryv5/enr
 
 export keys, enr
 
@@ -69,7 +68,7 @@ type
 # Util functions #
 ##################
 
-proc isValidHash(hashStr: string): bool =
+func isValidHash(hashStr: string): bool =
   ## Checks if a hash is valid. It should be the base32
   ## encoding of an abbreviated keccak256 hash.
   let decodedLen = Base32.decodedLength(hashStr.len())
@@ -85,7 +84,7 @@ proc isValidHash(hashStr: string): bool =
 
   return true
 
-proc hashableContent*(rootEntry: RootEntry): seq[byte] {.raises: [ValueError].} =
+func hashableContent*(rootEntry: RootEntry): seq[byte] {.raises: [ValueError].} =
   # Returns the hashable content of a root entry, used to compute the `sig=` portion
   return fmt"{RootPrefix} e={rootEntry.eroot} l={rootEntry.lroot} seq={rootEntry.seqNo}".toBytes()
 
@@ -93,7 +92,7 @@ proc hashableContent*(rootEntry: RootEntry): seq[byte] {.raises: [ValueError].} 
 # Entry parsers #
 #################
 
-proc parseRootEntry*(entry: string): EntryParseResult[RootEntry] =
+func parseRootEntry*(entry: string): EntryParseResult[RootEntry] =
   ## Parses a root entry in the format
   ## 'enrtree-root:v1 e=<enr-root> l=<link-root> seq=<sequence-number> sig=<signature>'
 
@@ -122,7 +121,7 @@ proc parseRootEntry*(entry: string): EntryParseResult[RootEntry] =
 
   ok(RootEntry(eroot: eroot, lroot: lroot, seqNo: uint32(seqNo), signature: signature))
 
-proc parseBranchEntry*(entry: string): EntryParseResult[BranchEntry] =
+func parseBranchEntry*(entry: string): EntryParseResult[BranchEntry] =
   ## Parses a branch entry in the format
   ## 'enrtree-branch:<h₁>,<h₂>,...,<hₙ>'
 
@@ -145,7 +144,7 @@ proc parseBranchEntry*(entry: string): EntryParseResult[BranchEntry] =
 
   ok(BranchEntry(children: hashes))
 
-proc parseEnrEntry*(entry: string): EntryParseResult[EnrEntry] =
+func parseEnrEntry*(entry: string): EntryParseResult[EnrEntry] =
   ## Parses an enr entry in the format 'enr:<node-record>'.
   ## <node-record> is the EIP-1459 text encoding of the node record
 
@@ -165,7 +164,7 @@ proc parseEnrEntry*(entry: string): EntryParseResult[EnrEntry] =
 
   ok(EnrEntry(record: record))
 
-proc parseLinkEntry*(entry: string): EntryParseResult[LinkEntry] =
+func parseLinkEntry*(entry: string): EntryParseResult[LinkEntry] =
   ## Parses a link entry in the format
   ## 'enrtree://<key>@<fqdn>'
 
@@ -195,7 +194,7 @@ proc parseLinkEntry*(entry: string): EntryParseResult[LinkEntry] =
                domain: fqdnStr,
                pubKey: key))
 
-proc parseSubtreeEntry*(entry: string): EntryParseResult[SubtreeEntry] =
+func parseSubtreeEntry*(entry: string): EntryParseResult[SubtreeEntry] =
   var subtreeEntry: SubtreeEntry
 
   try:
@@ -216,13 +215,13 @@ proc parseSubtreeEntry*(entry: string): EntryParseResult[SubtreeEntry] =
 # Tree accessors #
 ##################
 
-proc getNodes*(tree: Tree): seq[EnrEntry] {.raises: [ValueError]} =
+func getNodes*(tree: Tree): seq[EnrEntry] {.raises: []} =
   ## Returns a list of node entries in the tree
 
   return tree.entries.filterIt(it.kind == Enr)
                      .mapIt(it.enrEntry)
 
-proc getLinks*(tree: Tree): seq[LinkEntry] {.raises: [ValueError]} =
+func getLinks*(tree: Tree): seq[LinkEntry] {.raises: []} =
   ## Returns a list of link entries in the tree
 
   return tree.entries.filterIt(it.kind == Link)

--- a/tests/test_builder.nim
+++ b/tests/test_builder.nim
@@ -8,6 +8,22 @@ import
   ./test_utils
 
 procSuite "Test DNS Discovery: Merkle Tree builder":
+  setup:
+    let
+      exampleRecords = initExampleRecords()
+      exampleRoot = parseRootEntry(RootTxt).get()
+      exampleLink = parseSubtreeEntry(LinkTxt).get()
+      exampleBranch = parseSubtreeEntry(BranchTxt).get()
+      exampleEnr1 = parseSubtreeEntry(Enr1Txt).get()
+      exampleEnr2 = parseSubtreeEntry(Enr2Txt).get()
+      exampleEnr3 = parseSubtreeEntry(Enr3Txt).get()
+      exampleTree = Tree(rootEntry: exampleRoot,
+                          entries: @[exampleLink,
+                                     exampleBranch,
+                                     exampleEnr1,
+                                     exampleEnr2,
+                                     exampleEnr3])
+
   # Test tree entries:
 
   asyncTest "Create TXT records":

--- a/tests/test_tree.nim
+++ b/tests/test_tree.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[strutils, sequtils],
+  std/strutils,
   testutils/unittests,
   chronos,
   stew/[base64, results],

--- a/tests/test_utils.nim
+++ b/tests/test_utils.nim
@@ -1,6 +1,4 @@
-import
-  std/tables,
-  ../dnsdisc/tree
+import std/tables
 
 # Example tree constants, used in multiple tests
 const
@@ -20,7 +18,7 @@ const
   Enr3Txt* = "enr:-HW4QLAYqmrwllBEnzWWs7I5Ev2IAs7x_dZlbYdRdMUx5EyKHDXp7AV5CkuPGUPdvbv1_Ms1CPfhcGCvSElSosZmyoqAgmlkgnY0iXNlY3AyNTZrMaECriawHKWdDRk2xeZkrOXBQ0dfMFLHY4eENZwdufn1S1o"
 
 # Create sample tree from EIP-1459
-func initExampleRecords(): Table[string, string] =
+func initExampleRecords*(): Table[string, string] =
   var exampleRecords = initTable[string, string]()
 
   exampleRecords[Domain] = RootTxt
@@ -30,25 +28,4 @@ func initExampleRecords(): Table[string, string] =
   exampleRecords[Enr2Subdomain & "." & Domain] = Enr2Txt
   exampleRecords[Enr3Subdomain & "." & Domain] = Enr3Txt
 
-  return exampleRecords
-
-# Exported example tree variables, used in multiple tests
-let
-  exampleRecords* = initExampleRecords()
-
-  exampleRoot* = parseRootEntry(RootTxt).get()
-
-  exampleLink* = parseSubtreeEntry(LinkTxt).get()
-
-  exampleBranch* = parseSubtreeEntry(BranchTxt).get()
-
-  exampleEnr1* = parseSubtreeEntry(Enr1Txt).get()
-  exampleEnr2* = parseSubtreeEntry(Enr2Txt).get()
-  exampleEnr3* = parseSubtreeEntry(Enr3Txt).get()
-
-  exampleTree* = Tree(rootEntry: exampleRoot,
-                      entries: @[exampleLink,
-                                 exampleBranch,
-                                 exampleEnr1,
-                                 exampleEnr2,
-                                 exampleEnr3])
+  exampleRecords


### PR DESCRIPTION
- `exampleBranch` etc aren't `gcsafe` in the `async` tests. Nim 1.6 already warned about this, but Nim 2.0 makes it an error
- various unused imports also causing warnings, removed
- some functions were allowing extra exceptions in their exception specifications, which weren't actually possible. removed
- `proc` to `func` is just opportunistic, no semantic changes where it's allowed