### PR TITLE
chore: making syncTree public

### DIFF
--- a/dnsdisc/client.nim
+++ b/dnsdisc/client.nim
@@ -184,7 +184,7 @@ proc resolveRoot*(resolver: Resolver, loc: LinkEntry): Future[ResolveResult[Root
 
   return ok(res[])
 
-proc syncTree(resolver: Resolver, rootLocation: LinkEntry): Future[Result[Tree, cstring]] {.async.} =
+proc syncTree*(resolver: Resolver, rootLocation: LinkEntry): Future[Result[Tree, cstring]] {.async.} =
   ## Synchronises the client tree according to EIP-1459
 
   let rootEntry = await resolveRoot(resolver, rootLocation)


### PR DESCRIPTION
In Waku, we want to perform DNS Discovery without blocking the node's execution.
Currently, only a blocking implementation is defined

https://github.com/status-im/nim-dnsdisc/blob/38f853df30bcfdb73055b7fd7de284a47eebecc2/dnsdisc/client.nim#L226-L239

So making in this PR the `syncTree` procedure public so it can be used to perform the resolution asynchronously if needed.