### PR TITLE
use results instead of deprecated stew/results

### DIFF
--- a/dnsdisc/builder.nim
+++ b/dnsdisc/builder.nim
@@ -2,8 +2,9 @@
 
 import
   std/[sequtils, strformat, strutils, tables],
-  stew/[base64, base32, byteutils, results],
+  stew/[base64, base32, byteutils],
   nimcrypto/[hash, keccak],
+  results,
   ./tree
 
 export tree

--- a/dnsdisc/client.nim
+++ b/dnsdisc/client.nim
@@ -6,7 +6,8 @@ import
   chronos,
   eth/keys,
   nimcrypto/[hash, keccak],
-  stew/[base32, byteutils, results],
+  results,
+  stew/[base32, byteutils],
   ./tree
 
 export

--- a/dnsdisc/tree.nim
+++ b/dnsdisc/tree.nim
@@ -2,9 +2,10 @@
 
 import
   std/[strformat, strscans, strutils, sequtils],
-  stew/[base32, base64, byteutils, results],
+  stew/[base32, base64, byteutils],
   eth/keys,
-  eth/p2p/discoveryv5/enr
+  eth/p2p/discoveryv5/enr,
+  results
 
 export keys, enr
 

--- a/tests/test_tree.nim
+++ b/tests/test_tree.nim
@@ -4,7 +4,8 @@ import
   std/strutils,
   testutils/unittests,
   chronos,
-  stew/[base64, results],
+  stew/[base64],
+  results,
   ../dnsdisc/tree
 
 procSuite "Test DNS Discovery: Merkle Tree":


### PR DESCRIPTION
Getting error when trying to build nwaku with nimble due to `results` being removed from `stew`:

```
        ... /home/fryorcraken/.nimble/pkgs2/dnsdisc-0.1.0-5a3791c9e31660712eb6b53f9b3785a50b99e080/dnsdisc/client.nim(9, 7) Error: cannot open file: stew/results
```